### PR TITLE
添加了动态port的支持

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@
 您可以通过指定下列几个环境变量的值来使用外部的 MySQL 数据库：
 
 - `GHOST_MYSQL_HOST` 数据库主机地址
+- `GHOST_MYSQL_PORT` 数据库主机端口 (不填默认为3306)
 - `GHOST_MYSQL_DATABASE` 数据库名
 - `GHOST_MYSQL_USER` 数据库用户名
 - `GHOST_MYSQL_PASSWORD` 数据库密码
@@ -69,7 +70,7 @@
 
 ```console
 $ docker run -d -e MYSQL_ROOT_PASSWORD=example -e MYSQL_USER=ghost -e MYSQL_PASSWORD=ghost -e MYSQL_DATABASE=ghost -p 3306:3306 --name mymysql mysql    # 启动了一个 MySQL 实例并暴露端口 3306
-$ docker run -d -e GHOST_MYSQL_HOST=<mysql_host_address> -e GHOST_MYSQL_USER=ghost -e GHOST_MYSQL_PASSWORD=ghost -e GHOST_MYSQL_DATABASE=ghost -p 2368:2368 dghost    # 通过环境变量指定要使用数据库的连接方式
+$ docker run -d -e GHOST_MYSQL_HOST=<mysql_host_address> -e GHOST_MYSQL_PORT=3306 -e GHOST_MYSQL_USER=ghost -e GHOST_MYSQL_PASSWORD=ghost -e GHOST_MYSQL_DATABASE=ghost -p 2368:2368 dghost    # 通过环境变量指定要使用数据库的连接方式
 ```
 
 ---

--- a/adapter.sh
+++ b/adapter.sh
@@ -83,7 +83,7 @@ if [[ $is_mysql -eq 1 ]]; then
     echo ""
     echo "  \$GHOST_ROOT_URL = ${GHOST_ROOT_URL}"
     echo "  \$GHOST_MYSQL_HOST = ${GHOST_MYSQL_HOST}"
-    echo "  \GHOST_MYSQL_PORT = ${GHOST_MYSQL_PORT}"
+    echo "  \$GHOST_MYSQL_PORT = ${GHOST_MYSQL_PORT}"
     echo "  \$GHOST_MYSQL_USER = ${GHOST_MYSQL_USER}"
     echo "  \$GHOST_MYSQL_PASSWORD = ${GHOST_MYSQL_PASSWORD}"
     echo "  \$GHOST_MYSQL_DATABASE = ${GHOST_MYSQL_DATABASE}"

--- a/adapter.sh
+++ b/adapter.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+export DEFAULT_MYSQL_3306_PORT=3306
+
 # reset GHOST_SOURCE and GHOST_CONTENT, 
 # ghost will cover them in production mode
 export GHOST_SOURCE="/usr/src/ghost"
@@ -57,7 +59,7 @@ if [[ -n "$MYSQL_INSTANCE_NAME" ]]; then
         echo "INFO: Using http://changetoyoururl.daoapp.io temporary."
     fi
     export GHOST_MYSQL_HOST=$MYSQL_PORT_3306_TCP_ADDR
-    export GHOST_MYSQL_PORT=$MYSQL_PORT_3306_TCP_PORT
+    export GHOST_MYSQL_PORT=${MYSQL_PORT_3306_TCP_PORT:-DEFAULT_MYSQL_3306_PORT}
     export GHOST_MYSQL_USER=$MYSQL_USERNAME
     export GHOST_MYSQL_PASSWORD=$MYSQL_PASSWORD
     export GHOST_MYSQL_DATABASE=$MYSQL_INSTANCE_NAME
@@ -65,6 +67,7 @@ elif [[ -n "$MYSQL_ENV_MYSQL_VERSION" ]]; then
     echo "INFO: Using linked MySQL."
     is_mysql=1
     export GHOST_MYSQL_HOST=$MYSQL_PORT_3306_TCP_ADDR
+    export GHOST_MYSQL_PORT=${MYSQL_ENV_MYSQL_PORT:-DEFAULT_MYSQL_3306_PORT}
     export GHOST_MYSQL_USER=$MYSQL_ENV_MYSQL_USER
     export GHOST_MYSQL_PASSWORD=$MYSQL_ENV_MYSQL_PASSWORD
     export GHOST_MYSQL_DATABASE=$MYSQL_ENV_MYSQL_DATABASE

--- a/adapter.sh
+++ b/adapter.sh
@@ -57,6 +57,7 @@ if [[ -n "$MYSQL_INSTANCE_NAME" ]]; then
         echo "INFO: Using http://changetoyoururl.daoapp.io temporary."
     fi
     export GHOST_MYSQL_HOST=$MYSQL_PORT_3306_TCP_ADDR
+    export GHOST_MYSQL_PORT=$MYSQL_PORT_3306_TCP_PORT
     export GHOST_MYSQL_USER=$MYSQL_USERNAME
     export GHOST_MYSQL_PASSWORD=$MYSQL_PASSWORD
     export GHOST_MYSQL_DATABASE=$MYSQL_INSTANCE_NAME

--- a/adapter.sh
+++ b/adapter.sh
@@ -80,6 +80,7 @@ if [[ $is_mysql -eq 1 ]]; then
     echo ""
     echo "  \$GHOST_ROOT_URL = ${GHOST_ROOT_URL}"
     echo "  \$GHOST_MYSQL_HOST = ${GHOST_MYSQL_HOST}"
+    echo "  \GHOST_MYSQL_PORT = ${GHOST_MYSQL_PORT}"
     echo "  \$GHOST_MYSQL_USER = ${GHOST_MYSQL_USER}"
     echo "  \$GHOST_MYSQL_PASSWORD = ${GHOST_MYSQL_PASSWORD}"
     echo "  \$GHOST_MYSQL_DATABASE = ${GHOST_MYSQL_DATABASE}"

--- a/config_mysql.js
+++ b/config_mysql.js
@@ -17,6 +17,7 @@ config = {
             client: 'mysql',
             connection: {
                 host: process.env.GHOST_MYSQL_HOST,
+                port: process.env.GHOST_MYSQL_PORT,
                 user: process.env.GHOST_MYSQL_USER,
                 password: process.env.GHOST_MYSQL_PASSWORD,
                 database: process.env.GHOST_MYSQL_DATABASE,


### PR DESCRIPTION
DaoCloud 云端部署时目前 port 已经是动态端口了，默认的 3306 会导致无法连接数据库。
本修改增加了 port 的环境变量设置。